### PR TITLE
DEVAI-241: deprecate application gitops image

### DIFF
--- a/helm-charts/application-gitops/Containerfile
+++ b/helm-charts/application-gitops/Containerfile
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/python-39:latest
 
+LABEL deprecated="true"
+LABEL deprecated_message="This image is deprecated. No replacement image exists or is planned.
+
 WORKDIR /app
 
 COPY . .

--- a/helm-charts/application-gitops/README.md
+++ b/helm-charts/application-gitops/README.md
@@ -1,5 +1,7 @@
 # AI Software Template Helm Chart - Application GitOps Python Script
 
+**NOTE**: This image built around this Python script is deprecated.  No replacement image is planned.  Instead a GitOps Bash script running from the OCP build image is used. 
+
 The python script is responsible to create the application repository related with the deployment of the ai software template deployment. More details about the ai-software-templates helm chart can be found [here](https://github.com/redhat-ai-dev/ai-lab-helm-charts/blob/main/charts/ai-software-templates/chatbot/0.1.0/README.md).
 
 The image is uploaded to `quay.io/redhat-ai-dev/helm-chart-application-gitops`


### PR DESCRIPTION
### What does this PR do?:

Marks the application gitops image as deprecated

### Which issue(s) this PR fixes:

https://issues.redhat.com/browse/DEVAI-241


### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [/ ] Tested and Verified



- [/ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)


