### PR TITLE
Update Renovatebot To Group Dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,8 @@
     ":docker",
     ":gitSignOff",
     "helpers:pinGitHubActionDigests",
-    "mergeConfidence:all-badges"
+    "mergeConfidence:all-badges",
+    ":separateMajorReleases"
   ],
   "timezone": "America/Toronto",
   "description": "Run on the 1st and 15th of each month after midnight",
@@ -18,5 +19,19 @@
   },
   "osvVulnerabilityAlerts": true,
   "prHourlyLimit": 10,
-  "prConcurrentLimit": 10
+  "prConcurrentLimit": 10,
+  "packageRules": [
+      {
+        "matchManagers": ["github-actions"],
+        "groupName": "github-actions"
+      },
+      {
+        "matchManagers": ["pep621", "pep723", "pip-compile", "pip_requirements", "pip_setup", "pipenv", "poetry", "pyenv", "runtime-version", "setup-cfg"],
+        "groupName": "python"
+      },
+      {
+        "matchManagers": ["dockerfile"],
+        "groupName": "container-images"
+      }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,10 +28,6 @@
       {
         "matchManagers": ["pep621", "pep723", "pip-compile", "pip_requirements", "pip_setup", "pipenv", "poetry", "pyenv", "runtime-version", "setup-cfg"],
         "groupName": "python"
-      },
-      {
-        "matchManagers": ["dockerfile"],
-        "groupName": "container-images"
       }
   ]
 }


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR aims to group the dependencies by their type, in this case it will attempt to group them in one of the following 3:
- gh actions
- python
- container images

I also added a piece that ensures that major updates are separated from the groups so we don't need to fiddle with breaking grouped changes.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

N/A, done in response to https://github.com/redhat-ai-dev/developer-images/pull/22#issuecomment-2558148858

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

### How to test changes / Special notes to the reviewer:
Need to verify if Renovate can pick these changes up via PR, may need to give it a quick test on my local repo first as well. 