### PR TITLE
exclude vllm changes from validation and upload

### DIFF
--- a/.github/workflows/upload-image.yml
+++ b/.github/workflows/upload-image.yml
@@ -36,6 +36,11 @@ jobs:
         BASE_DIR=$(pwd)
         for dir in ${ALL_CHANGED_FILES}; do
             echo "Change detected in $dir ..."
+            prevdir=$(dirname $dir)
+            if [ $prevdir == "model-servers/vllm" ]; then
+                echo "Skipping uploading of vllm model server changes! Please perform a manual upload ..."
+                continue
+            fi
             cd $dir
             if [ ! -f config.env ]; then
                 echo "No config.env file present in changed directory, skipping ..."

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -29,6 +29,11 @@ jobs:
         BASE_DIR=$(pwd)
         for dir in ${ALL_CHANGED_FILES}; do
             echo "Change detected in $dir ..."
+            prevdir=$(dirname $dir)
+            if [ $prevdir == "model-servers/vllm" ]; then
+                echo "Skipping validation of vllm model server changes! Please perform a manual validation ..."
+                continue
+            fi
             cd $dir
             if [ ! -f config.env ] && ([ -f Dockerfile ] || [ -f Containerfile ]); then
                 echo "No config.env file present in changed directory that contains image files. Throwing error ..."


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
excludes vllm model server images from validation and upload due to the sheer size of the images. For example, if you are building a vllm image of 5Gi, the CI is going to run out of storage. 

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
<img width="899" alt="Screenshot 2025-01-21 at 5 33 58 PM" src="https://github.com/user-attachments/assets/a7bc661b-2a55-42cb-b714-234d53656c75" />
<img width="834" alt="Screenshot 2025-01-21 at 5 34 35 PM" src="https://github.com/user-attachments/assets/bf00d20f-f811-4ab2-8cf7-95da8d0bf780" />
