### PR TITLE
[RHDHPAI-633] Bump Chroma Version To 0.5.23

### DIFF
--- a/database/chroma/Containerfile
+++ b/database/chroma/Containerfile
@@ -1,2 +1,2 @@
-FROM chromadb/chroma:0.5.5
+FROM chromadb/chroma:0.5.23
 RUN chgrp -R 0 /chroma && chmod -R g=u /chroma

--- a/database/chroma/README.md
+++ b/database/chroma/README.md
@@ -5,3 +5,7 @@ The Chroma database Containerfile is a simple wrapper that gives group permissio
 ## Quay Repository
 
 This image is uploaded to the quay repository `quay.io/repository/redhat-ai-dev/chroma`.
+
+## Versioning
+
+The version of Chroma used in this Container should match the dependency version located in the [sample application](https://github.com/redhat-ai-dev/ai-lab-samples/blob/main/rag/requirements.txt#L3).


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR bumps the Chroma version to `0.5.23` to match the chroma dependency version that will be pulled in as part of https://github.com/redhat-ai-dev/ai-lab-samples/pull/20. These versions have to match to avoid errors.

I have made a copy of the current `latest` tag of Chroma located in quay.io and tagged it as `0.5.13` for historical records/rollbacks, when all of the changes related to this are complete I will go ahead and push the `0.5.23` tagged image as `latest` as well. Tags: https://quay.io/repository/redhat-ai-dev/chroma?tab=tags

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

Part of https://issues.redhat.com/browse/RHDHPAI-633

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
